### PR TITLE
refactor: Remove redundant code for setting up Python

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,10 +29,6 @@ inputs:
     description: 'Show summary information in logs'
     required: false
     default: 'true'
-  runtime:
-    description: 'Runtime to use (nodejs or python)'
-    required: false
-    default: 'nodejs'
   per-page:
     description: 'Results per page (max 100)'
     required: false
@@ -56,27 +52,10 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Node.js
-      if: inputs.runtime == 'nodejs'
       uses: actions/setup-node@v4
       with:
         node-version: '18.x'
-        
-    - name: Set up Python
-      if: inputs.runtime == 'python'
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-        
-    - name: Install Python dependencies
-      if: inputs.runtime == 'python'
-      shell: bash
-      run: |
-        if [ -f requirements.txt ]; then
-          pip install -r requirements.txt
-        else
-          pip install requests
-        fi
-        
+
     - name: Retrieve Copilot licenses
       id: retrieve-licenses
       shell: bash
@@ -84,53 +63,46 @@ runs:
         GITHUB_ENTERPRISE: ${{ inputs.enterprise }}
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
-        # Determine the script to run
-        if [ "${{ inputs.runtime }}" = "nodejs" ]; then
-          SCRIPT_CMD="node ${{ github.action_path }}/get_copilot_licenses.js"
-        else
-          SCRIPT_CMD="python ${{ github.action_path }}/get_copilot_licenses.py"
-        fi
-        
         # Build the command arguments
         ARGS="--enterprise ${{ inputs.enterprise }}"
         ARGS="$ARGS --per-page ${{ inputs.per-page }}"
-        
+
         if [ "${{ inputs.include-billing }}" = "true" ]; then
           ARGS="$ARGS --billing"
         fi
-        
+
         if [ "${{ inputs.include-summary }}" = "true" ]; then
           ARGS="$ARGS --summary"
         fi
-        
+
         # Generate JSON file
         JSON_FILE="${{ inputs.output-file }}_$(date +%Y%m%d).json"
         echo "Generating JSON report: $JSON_FILE"
-        $SCRIPT_CMD $ARGS --output "$JSON_FILE" --format json
-        
+        node ${{ github.action_path }}/get_copilot_licenses.js $ARGS --output "$JSON_FILE" --format json
+
         # Generate CSV file if requested
         if [ "${{ inputs.output-format }}" = "csv" ] || [ "${{ inputs.output-format }}" = "both" ]; then
           CSV_FILE="${{ inputs.output-file }}_$(date +%Y%m%d).csv"
           echo "Generating CSV report: $CSV_FILE"
-          $SCRIPT_CMD $ARGS --output "$CSV_FILE" --format csv
+          node ${{ github.action_path }}/get_copilot_licenses.js $ARGS --output "$CSV_FILE" --format csv
           echo "csv-file=$CSV_FILE" >> $GITHUB_OUTPUT
         fi
-        
+
         # Extract information from JSON for outputs
         if [ -f "$JSON_FILE" ]; then
           TOTAL_SEATS=$(jq -r '.total_seats' "$JSON_FILE")
           ORGANIZATIONS=$(jq -r '[.seats[].organization.login] | unique | join(",")' "$JSON_FILE")
-          
+
           echo "total-seats=$TOTAL_SEATS" >> $GITHUB_OUTPUT
           echo "json-file=$JSON_FILE" >> $GITHUB_OUTPUT
           echo "organizations=$ORGANIZATIONS" >> $GITHUB_OUTPUT
-          
+
           echo "✅ Successfully retrieved $TOTAL_SEATS Copilot licenses"
         else
           echo "❌ Failed to generate license report"
           exit 1
         fi
-        
+
     - name: Create step summary
       if: inputs.include-summary == 'true'
       shell: bash
@@ -146,14 +118,14 @@ runs:
         echo "**💺 Total Seats:** $TOTAL_SEATS" >> $GITHUB_STEP_SUMMARY
         echo "**📁 Output File:** $JSON_FILE" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        
+
         # Organizations breakdown
         if [ -n "$ORGANIZATIONS" ]; then
           echo "### 🏢 Organizations" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Organization | Seats |" >> $GITHUB_STEP_SUMMARY
           echo "|-------------|-------|" >> $GITHUB_STEP_SUMMARY
-          
+
           # Count seats per organization from the JSON file
           if [ -f "$JSON_FILE" ]; then
             jq -r '
@@ -163,12 +135,12 @@ runs:
             ' "$JSON_FILE" >> $GITHUB_STEP_SUMMARY
           fi
         fi
-        
+
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### 📋 Files Generated" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "- 📄 JSON: \`$JSON_FILE\`" >> $GITHUB_STEP_SUMMARY
-        
+
         if [ -n "${{ steps.retrieve-licenses.outputs.csv-file }}" ]; then
           echo "- 📊 CSV: \`${{ steps.retrieve-licenses.outputs.csv-file }}\`" >> $GITHUB_STEP_SUMMARY
         fi


### PR DESCRIPTION
This pull request simplifies the `action.yaml` file by removing support for Python as a runtime and standardizing the action to use Node.js exclusively. The most important changes include the removal of Python-specific inputs, steps, and logic, as well as updates to ensure that all commands now use Node.js.

### Removal of Python runtime support:
* Removed the `runtime` input, which allowed users to select between Node.js and Python.
* Deleted Python-specific setup steps, including installing Python dependencies and configuring the Python runtime.
* Removed conditional logic that determined whether to use the Node.js or Python script for retrieving Copilot licenses. All logic now directly references the Node.js script. [[1]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL59-L93) [[2]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL109-R87)

### Standardization on Node.js:
* Updated all script execution commands to exclusively use the Node.js script `get_copilot_licenses.js`.